### PR TITLE
Add support for @paralleldrive/cuid2

### DIFF
--- a/src/prunestep.ts
+++ b/src/prunestep.ts
@@ -131,11 +131,17 @@ export class PruneStep {
       "node_modules/@paralleldrive/cuid2/index.js",
       "node_modules/@paralleldrive/cuid2/LICENSE",
       "node_modules/@paralleldrive/cuid2/src/index.js",
-
+      
       "node_modules/memoize-one/README.md",
       "node_modules/memoize-one/LICENSE",
       "node_modules/memoize-one/package.json",
       "node_modules/memoize-one/dist/memoize-one.cjs.js",
+
+      "node_modules/@noble/hashes/*.js",
+      "node_modules/@noble/hashes/LICENSE",
+
+      "node_modules/bignumber.js/bignumber.js",
+      "node_modules/bignumber.js/LICENCE.md",
     ];
 
     const nodeguiDeleteList = [
@@ -245,6 +251,9 @@ export class PruneStep {
     logger.info("Pruning empty directories");
     await pruneEmptyDirectories(".");
 
+    logger.info("Fix bignumber.js");
+    shell.mv("node_modules/bignumber.js/bignumber.js", "node_modules/bignumber.js/index.js");
+    
     shell.cd(prepareStep.getTempDirectory());
     const env: { [key: string]: string } = {};
     prepareStep.addVariables(env);

--- a/src/prunestep.ts
+++ b/src/prunestep.ts
@@ -251,8 +251,10 @@ export class PruneStep {
     logger.info("Pruning empty directories");
     await pruneEmptyDirectories(".");
 
-    logger.info("Fix bignumber.js");
-    shell.mv("node_modules/bignumber.js/bignumber.js", "node_modules/bignumber.js/index.js");
+    if (shell.test("-f", "node_modules/bignumber.js/bignumber.js")) {
+      logger.info("Fix bignumber.js");
+      shell.mv("node_modules/bignumber.js/bignumber.js", "node_modules/bignumber.js/index.js");
+    }
     
     shell.cd(prepareStep.getTempDirectory());
     const env: { [key: string]: string } = {};

--- a/src/prunestep.ts
+++ b/src/prunestep.ts
@@ -128,6 +128,9 @@ export class PruneStep {
       "node_modules/cuid/lib/*.js",
       "node_modules/cuid/LICENSE",
       "node_modules/cuid/package.json",
+      "node_modules/@paralleldrive/cuid2/index.js",
+      "node_modules/@paralleldrive/cuid2/LICENSE",
+      "node_modules/@paralleldrive/cuid2/src/index.js",
 
       "node_modules/memoize-one/README.md",
       "node_modules/memoize-one/LICENSE",


### PR DESCRIPTION
This updates `nodeguiAcceptList` to support _@paralleldrive/cuid2_.

I'm not sure why, but I also had to change one filename for it to work.

I tested that the changes didn't break packaging _nodegui-simple-starter_ on linux.